### PR TITLE
Faster mongoimport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,7 @@ venv.bak/
 *.CSV
 *.csv.zip
 *.CSV.zip
+*master*.txt
 
 .mypy_cache/
 .idea/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a set of programs for loading the [GDELT 2.0](https:/gdeltproject.org) d
 
 ## Quick Start
 
-Install the latest version of Python from [python.org](https://www.python.org/downloads/)
+Install the latest version of Python from [python.org](https://www.python.org/downloads/).
 You need at least version 3.6 for this program. Many versions of Python that
 come pre-installed are only 2.7. This version will not work.
 
@@ -20,7 +20,7 @@ Now get the master file of all the GDELT files.
 gdeltloader --master
 ```
 
-This will generate a file named something like `gdelt-master-file-04-19-2022-19-33-56.txt`
+This will generate a file named something like `masterfilelist.txt`
 
 ## Downloading the master data set
 
@@ -44,17 +44,17 @@ you want to download:
 ```shell
 gdeltloader --master --download --overwrite --last 20
 ```
-Will download the most recent 20 files worth of data. Not that a file is a triplet of 
+This command will download the most recent 20 files worth of data. Note that a file is a triplet of 
 `export`, `mentions` and `gkg` data. If you only want one you should specify a 
 `--filter`. Without the filter a command like the above will actually download 60 files. 
 
 ### GDELT 2.0 Encoding and Structure
 The [GDELT](https://gdeltproject.org) dataset is a large dataset of news events that is updated
 in real-time. GDELT stands for Global Database of Events Location and Tone. The format
-of records in a GDELT data is defined by the [GDELT 2.0 Cookbook](http://data.gdeltproject.org/documentation/GDELT-Event_Codebook-V2.0.pdf)
+of records in a GDELT data is defined by the [GDELT 2.0 Codebook](http://data.gdeltproject.org/documentation/GDELT-Event_Codebook-V2.0.pdf)
 
 Each record uses an encoding method called CAMEO coding which is defined by the
-[CAMEO cookbook](https://parusanalytics.com/eventdata/cameo.dir/CAMEO.Manual.1.1b3.pdf).
+[CAMEO Codebook](https://parusanalytics.com/eventdata/cameo.dir/CAMEO.Manual.1.1b3.pdf).
 
 Once you understand the GDELT recording structure and the CAMEO encoding you will be able
 to decode a record. To fully decode a record you may need the 
@@ -63,18 +63,16 @@ from which the CAMEO encoding is derived.
 
 ## How to download GDELT 2.0 data
 
-The `gdeltloader` script can download cameo data an unzip the files so that
+The `gdeltloader` script can download cameo data and unzip the files so that
 they can be loaded into MongoDB.
 
 ```
-usage: gdeltloader [-h] [--host HOST] [--master] [--update]
-                   [--database DATABASE] [--collection COLLECTION]
-                   [--local LOCAL] [--overwrite] [--download] [--metadata]
-                   [--filefilter {export,gkg,mentions,all}] [--last LAST]
+usage: gdeltloader [-h] [--master] [--update] [--database DATABASE] [--collection COLLECTION]
+  [--local LOCAL] [--overwrite] [--download] [--metadata]
+  [--filter {all,gkg,mentions,export}] [--last LAST] [--version]
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
-  --host HOST           MongoDB URI
   --master              GDELT master file [False]
   --update              GDELT update file [False]
   --database DATABASE   Default database for loading [GDELT]
@@ -84,12 +82,12 @@ optional arguments:
   --overwrite           Overwrite files when they exist already
   --download            download zip files from master or local file
   --metadata            grab meta data files
-  --filefilter {export,gkg,mentions,all}
-                        download a subset of the data, the default is the
-                        export data
-  --last LAST           how many recent days of data to download [365]
+  --filter {all,gkg,mentions,export}
+                        download a subset of the data, the default is all data [export, mentions gkg, all]
+  --last LAST           how many recent files to download default : [0] implies all files
+  --version             show program's version number and exit
 
-Version: 0.06a
+Version: 0.07b1 More info : https://github.com/jdrumgoole/gdelttools
 ```
 
 Here is how to download the last 5 hours of GDELT data. 
@@ -97,6 +95,7 @@ Here is how to download the last 5 hours of GDELT data.
 ```shell
 gdeltloader --master --update --download --last 20
 ```
+
 This command will only download the `export` files for the last 20 15-minute blocks, which
 are the files we are interested in. 
 
@@ -117,7 +116,7 @@ To run:
 sh mongoimport.sh --uri "<YOUR-MONGODB-CONNECTION-STRING>"
 ```
 
-it will upload all the CSV files in the current working directory. 
+This will upload all the CSV files in the current working directory. 
 
 
 

--- a/README.md
+++ b/README.md
@@ -92,12 +92,12 @@ optional arguments:
 Version: 0.06a
 ```
 
-Here is how to download the last 365 days of GDELT data. 
+Here is how to download the last 5 hours of GDELT data. 
 
+```shell
+gdeltloader --master --update --download --last 20
 ```
-gdeltloader --master --update --download --last 365``
-````
-This command will only download the `export` files for the last 365 days which
+This command will only download the `export` files for the last 20 15-minute blocks, which
 are the files we are interested in. 
 
 ## How to import downloaded data into MongoDB
@@ -113,7 +113,9 @@ which this script uses to ensure correct type mappings.
 
 To run:
 
-`sh mongoimport.sh`
+```shell
+sh mongoimport.sh --uri "<YOUR-MONGODB-CONNECTION-STRING>"
+```
 
 it will upload all the CSV files in the current working directory. 
 

--- a/mongoimport.sh
+++ b/mongoimport.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env sh
-for i in *.export.CSV
-do
-  mongoimport --db=GDELT2 --collection=eventscsv  --type=tsv --fieldFile=gdelt_field_file.ff --mode=upsert --writeConcern "{w:1}" --columnsHaveTypes --file=$i $*
-done
-
+cat *.export.CSV \
+    | mongoimport \
+        --collection=eventscsv \
+        --mode=upsert \
+        --writeConcern "{w:1}" \
+        --type=tsv \
+        --columnsHaveTypes \
+        --fieldFile=gdelt_field_file.ff \
+        $*

--- a/mongoimport.sh
+++ b/mongoimport.sh
@@ -7,13 +7,39 @@
 # 
 # ./mongoimport.sh --uri "mongodb+srv://<username>:<password>@abcde.mongodb.com/<yourdatabase>"
 
+findme() {
+    # Function for finding the path of a shell script,
+    # taken from https://stackoverflow.com/a/246128
+    TARGET_FILE=$0
+
+    cd `dirname $TARGET_FILE`
+    TARGET_FILE=`basename $TARGET_FILE`
+
+    # Iterate down a (possible) chain of symlinks
+    while [ -L "$TARGET_FILE" ]
+    do
+        TARGET_FILE=`readlink $TARGET_FILE`
+        cd `dirname $TARGET_FILE`
+        TARGET_FILE=`basename $TARGET_FILE`
+    done
+
+    # Compute the canonicalized name by finding the physical path 
+    # for the directory we're in and appending the target file.
+    PHYS_DIR=`pwd -P`
+    RESULT=$PHYS_DIR/$TARGET_FILE
+    echo $RESULT
+}
+
+myloc=$(dirname $(findme $0))
+
+fieldfile="${myloc}/gdelt_field_file.ff"
 
 cat *.export.CSV \
     | mongoimport \
         --collection=eventscsv \
         --mode=upsert \
-        --writeConcern "{w:1}" \
+        --writeConcern '{w:1}' \
         --type=tsv \
         --columnsHaveTypes \
-        --fieldFile=gdelt_field_file.ff \
+        --fieldFile="${fieldfile}" \
         $*

--- a/mongoimport.sh
+++ b/mongoimport.sh
@@ -1,4 +1,13 @@
 #!/usr/bin/env sh
+# Upload all the CSV files in your current directory to a MongoDB cluster.
+#
+# Any parameters passed to this command are passed to mongoimport, so to
+# connect to your cluster, provide the --uri parameter with your MongoDB
+# connection string, like this:
+# 
+# ./mongoimport.sh --uri "mongodb+srv://<username>:<password>@abcde.mongodb.com/<yourdatabase>"
+
+
 cat *.export.CSV \
     | mongoimport \
         --collection=eventscsv \

--- a/mongoimport.sh
+++ b/mongoimport.sh
@@ -34,12 +34,11 @@ myloc=$(dirname $(findme $0))
 
 fieldfile="${myloc}/gdelt_field_file.ff"
 
-cat *.export.CSV \
-    | mongoimport \
-        --collection=eventscsv \
-        --mode=upsert \
-        --writeConcern '{w:1}' \
-        --type=tsv \
-        --columnsHaveTypes \
-        --fieldFile="${fieldfile}" \
+cat *.export.CSV | mongoimport \
+    --collection=eventscsv \
+    --mode=upsert \
+    --writeConcern '{w:1}' \
+    --type=tsv \
+    --columnsHaveTypes \
+    --fieldFile="${fieldfile}" \
         $*


### PR DESCRIPTION
I've modified mongoimport.sh to only run mongoimport once, and all the CSV files are piped in. Makes it quite a bit faster, especially with lots of small files.

I've also added some comments about how to run it, and enabled it to be run from another directory (by tracking down where the script is, and loading the .ff file from there).